### PR TITLE
Update default.py

### DIFF
--- a/default.py
+++ b/default.py
@@ -46,7 +46,7 @@ sys.path.append(BASE_RESOURCE_PATH)
 PLEXBMC_VERSION="3.1.0"
 
 from listener import *
-import plexgdm
+import plexGDM
 
 def printDebug( msg, functionname=True ):
     if g_debug == "true":


### PR DESCRIPTION
I have tested the plexbmc helper, it crashes because the import of plexgdm is bad, it is case sensitive and the lib is named plexGDM.py, so rename the lib to plexgdm.py or do an import plexGDM...
